### PR TITLE
Unique Naming Solution

### DIFF
--- a/src/closure/closure.lisp
+++ b/src/closure/closure.lisp
@@ -42,6 +42,14 @@
                   :table (syc:tree-map-insert (table closure) name bound-value))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Dumping Functions
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(-> keys (typ) list)
+(defun keys (closure)
+  (sycamore:tree-map-keys (table closure)))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Lookup Functions
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/src/closure/package.lisp
+++ b/src/closure/package.lisp
@@ -13,7 +13,8 @@
    :insert
    :length
    :lookup
-   :remove))
+   :remove
+   :keys))
 
 (defpackage #:alu.closure.dependency
   (:documentation "Provides a dependency closure that shows dependency

--- a/test/expand.lisp
+++ b/test/expand.lisp
@@ -21,7 +21,9 @@
         "utx is not a primitve type and should be expanded properly")
     (is (typep (caddr expanded-storage) 'expand:expand)
         (format nil "UTX should turn into an expand type"))
-    (is (eq :utx (expand:original (caddr expanded-storage)))
+    (is (alexandria:starts-with-subseq
+         "UTX"
+         (symbol-name (expand:original (caddr expanded-storage))))
         "we preserve the name of the utx")
     (is (= 3 (length (expand:expanded (caddr expanded-storage))))
         "The arguments should be expanded to 3 argument wide")))

--- a/test/global-examples.lisp
+++ b/test/global-examples.lisp
@@ -218,9 +218,16 @@
     x₁))
 
 (defun square-root-func (p)
-  (def ((with-constraint (x1)
+  (def ((x2 5)
+        (with-constraint (x1)
           (= p (* x1 x1))))
     x1))
+
+(defcircuit test-square ((output int))
+  (def ((x1 5))
+    (square-root-func 7)
+    x1))
+
 
 (defcircuit l2-norm ((public p 3d-point)
                      (output int))
@@ -229,7 +236,6 @@
     (square-root
      (sum (mapcar (lambda (x) (exp x 2))
                   (list (x-plane p) (y-plane p) (z-plane p)))))))
-
 
 (defcircuit l2-norm-by-hand ((public p 3d-point)
                              (output int))

--- a/test/pass.lisp
+++ b/test/pass.lisp
@@ -37,14 +37,10 @@
     (is (= 1 (length ran)))))
 
 (test renaming
-  (let ((expected-args '(:ROOT :SIG :UTX_PLANE_X :UTX_PLANE_Y
-                         :UTX_TIME_X :UTX_TIME_Y))
-        (ran  (pipeline:to-primitive-circuit (storage:lookup-function :record-test)))
+  (let ((ran  (pipeline:to-primitive-circuit (storage:lookup-function :record-test)))
         (ran2 (pipeline:to-primitive-circuit (storage:lookup-function :record-test-mult)))
         (ran3 (pipeline:to-primitive-circuit (storage:lookup-function :use-constrain))))
     ran2 ran3
-    (is (equalp expected-args (ir:arguments ran))
-        "Renaming is consistent")
     (is (every (lambda (x)
                  (not
                   (or (string-contains-p "&" x)

--- a/test/relocation.lisp
+++ b/test/relocation.lisp
@@ -121,10 +121,13 @@
                                 :hi)))))
 
 (test initial-closure-from-circuit
-  (let ((expected-storage '((:X . :SIG-X) (:Y . :SIG-Y)))
+  (let* ((sig-arugment
+           (ir:name
+            (cadr (ir:arguments (storage:lookup-function :arg-circuit-input)))))
+         (expected-storage '((:X . :SIG-X) (:Y . :SIG-Y)))
 
-        (closure (relocate:initial-closure-from-circuit
-                  (storage:lookup-function :arg-circuit-input))))
+         (closure (relocate:initial-closure-from-circuit
+                   (storage:lookup-function :arg-circuit-input))))
 
     ;; Tests begin here
     (is (equalp expected-storage (closure:lookup closure :sig)))

--- a/test/relocation.lisp
+++ b/test/relocation.lisp
@@ -121,15 +121,15 @@
                                 :hi)))))
 
 (test initial-closure-from-circuit
-  (let* ((sig-arugment
-           (ir:name
-            (cadr (ir:arguments (storage:lookup-function :arg-circuit-input)))))
-         (expected-storage '((:X . :SIG-X) (:Y . :SIG-Y)))
+  (let* ((closure (relocate:initial-closure-from-circuit
+                   (storage:lookup-function :arg-circuit-input)))
 
-         (closure (relocate:initial-closure-from-circuit
-                   (storage:lookup-function :arg-circuit-input))))
+         (keys (closure:keys closure))
+         (expected-storage `((:X . ,(intern (format nil "~A-X" (car keys)) :keyword))
+                             (:Y . ,(intern (format nil "~A-Y" (car keys)) :keyword)))))
 
     ;; Tests begin here
-    (is (equalp expected-storage (closure:lookup closure :sig)))
+    (is (= 1 (length keys)))
+    (is (equalp expected-storage (closure:lookup closure (car keys))))
     (is (equalp nil (closure:lookup closure :root))
         "Root is not a record, we don't ingest it.")))


### PR DESCRIPTION
This PR fixes the ambiguity of names found in CL code see issue #27.

A follow up PR should be had where we prettify the names, as the generated vamp-ir is now uglier

```lisp
ALU-TEST> (pipeline:pipeline (storage:lookup-function :l2-norm))
def l2_norm p23926_x_plane p23926_y_plane p23926_z_plane -> vg24007 {
  g23999 = p23926_x_plane
  g24000 = p23926_y_plane
  g24001 = p23926_z_plane
  g24002 = g23999 ^ 2
  g24003 = g24000 ^ 2
  g24004 = g24001 ^ 2
  g24005 = g24002 + (g24003 + g24004)
  g24006 = square_root g24005
  vg24007 = g24006
}
```