### PR TITLE
Stepping Functionality

### DIFF
--- a/alu.asd
+++ b/alu.asd
@@ -145,6 +145,7 @@
    (:file "pass")
    (:file "vampir")
    (:file "stack")
+   (:file "step")
    (:file "run-tests"))
   :perform (asdf:test-op (o s)
                          (uiop:symbol-call :alu-test :run-tests)))

--- a/alu.asd
+++ b/alu.asd
@@ -1,6 +1,6 @@
 (asdf:defsystem :alu
   :depends-on (:trivia :alexandria :sycamore :serapeum :closer-mop :command-line-arguments
-                       ;; (:version "asdf" "3.3.5")
+                       (:version "asdf" "3.3.5")
                        :swank :slynk
                        :cl-environments)
   :version "0.0.0"

--- a/alu.asd
+++ b/alu.asd
@@ -1,7 +1,7 @@
 (asdf:defsystem :alu
   :depends-on (:trivia :alexandria :sycamore :serapeum :closer-mop :command-line-arguments
-                       (:version "asdf" "3.3.5")
-                       :swank :slynk)
+                       ;; (:version "asdf" "3.3.5")
+               :swank :slynk)
   :version "0.0.0"
   :description "Powering Vamp-IR with the power of the original lineage"
   :author "Mariari"
@@ -97,6 +97,19 @@
                  (:file "array")
                  (:file "dependencies")
                  (:file "pipeline")))
+   (:module stepper
+    :serial t
+    ;; we need symbols like `alu:def' in scope, in the future we
+    ;; should remove the dependency on package and have a way of
+    ;; extending our stepper with new primitives, and ways of stepping
+    ;; through it. So we can instrument our specials in (:file alu)
+    ;; instead.
+    :depends-on (package stack)
+    :description "Provides a syntax stepper that can step through the
+    syntax of common lisp and allow instrumenting syntax such that a
+    stack can be implemented."
+    :components ((:file "package")
+                 (:file "stepper")))
    ;; only folder without a package
    (:module prelude
     :serial t
@@ -104,8 +117,8 @@
     :depends-on  ("alu")
     :pathname #P"../alu/"
     :components ((:file "prelude")))
-   (:file "package" :depends-on ("specification"))
-   (:file "alu"     :depends-on ("package"))
+   (:file "package"     :depends-on ("specification"))
+   (:file "alu"         :depends-on ("package"))
    (:file "../app/main" :depends-on ("alu" "prelude")))
   :in-order-to ((asdf:test-op (asdf:test-op :alu/test))))
 
@@ -131,6 +144,21 @@
    (:file "vampir")
    (:file "stack")
    (:file "run-tests"))
+  :perform (asdf:test-op (o s)
+                         (uiop:symbol-call :alu-test :run-tests)))
+
+;; Big TODO, figure out how to get good docs for Our project!
+(asdf:defsystem :alu/documentation
+  :depends-on (:fiveam
+               :swank :slynk
+               :staple
+               :staple-server :asdf-package-system
+               :staple-restructured-text)
+  :description "Documenting alu"
+  :pathname "test/"
+  :serial t
+  :components
+  ()
   :perform (asdf:test-op (o s)
                          (uiop:symbol-call :alu-test :run-tests)))
 

--- a/alu.asd
+++ b/alu.asd
@@ -1,7 +1,8 @@
 (asdf:defsystem :alu
   :depends-on (:trivia :alexandria :sycamore :serapeum :closer-mop :command-line-arguments
                        ;; (:version "asdf" "3.3.5")
-               :swank :slynk)
+                       :swank :slynk
+                       :cl-environments)
   :version "0.0.0"
   :description "Powering Vamp-IR with the power of the original lineage"
   :author "Mariari"

--- a/alu.asd
+++ b/alu.asd
@@ -110,7 +110,8 @@
     syntax of common lisp and allow instrumenting syntax such that a
     stack can be implemented."
     :components ((:file "package")
-                 (:file "stepper")))
+                 (:file "stepper")
+                 (:file "define")))
    ;; only folder without a package
    (:module prelude
     :serial t

--- a/clpmfile.lock
+++ b/clpmfile.lock
@@ -34,44 +34,103 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 :releases
+("3bmd" :version "2021-04-11" :source "quicklisp" :systems
+ ("3bmd" "3bmd-ext-code-blocks"))
+("acclimation" :version "2020-09-25" :source "quicklisp" :systems
+ ("acclimation"))
 ("alexandria" :version "2022-04-01" :source "quicklisp" :systems ("alexandria"))
-("alu.asd" :version :newest :source :implicit-file :systems ("alu" "alu/test"))
+("alu.asd" :version :newest :source :implicit-file :systems
+ ("alu" "alu/documentation" "alu/test"))
+("anaphora" :version "2022-02-20" :source "quicklisp" :systems ("anaphora"))
+("array-utils" :version "2020-12-20" :source "quicklisp" :systems
+ ("array-utils"))
 ("asdf-flv" :version "2016-04-21" :source "quicklisp" :systems
  ("net.didierverna.asdf-flv"))
+("asdf-package-system" :version "2015-06-08" :source "quicklisp" :systems
+ ("asdf-package-system"))
 ("atomics" :version "2021-06-30" :source "quicklisp" :systems ("atomics"))
+("babel" :version "2020-09-25" :source "quicklisp" :systems ("babel"))
 ("bordeaux-threads" :version "2020-06-10" :source "quicklisp" :systems
  ("bordeaux-threads"))
+("cffi" :version "2021-04-11" :source "quicklisp" :systems ("cffi"))
+("chunga" :version "2022-04-01" :source "quicklisp" :systems ("chunga"))
+("cl+ssl" :version "2022-04-01" :source "quicklisp" :systems ("cl+ssl"))
+("cl-base64" :version "2020-10-16" :source "quicklisp" :systems ("cl-base64"))
+("cl-data-format-validation" :version "2014-07-13" :source "quicklisp" :systems
+ ("data-format-validation"))
+("cl-docutils" :version "2013-01-28" :source "quicklisp" :systems ("docutils"))
+("cl-environments" :version "2021-10-21" :source "quicklisp" :systems
+ ("cl-environments"))
+("cl-fad" :version "2022-02-20" :source "quicklisp" :systems ("cl-fad"))
 ("cl-fuzz" :version "2018-10-18" :source "quicklisp" :systems ("cl-fuzz"))
+("cl-markless" :version "2022-04-01" :source "quicklisp" :systems
+ ("cl-markless" "cl-markless-plump"))
 ("cl-ppcre" :version "2022-02-20" :source "quicklisp" :systems ("cl-ppcre"))
+("clip" :version "2021-12-09" :source "quicklisp" :systems ("clip"))
 ("closer-mop" :version "2022-04-01" :source "quicklisp" :systems ("closer-mop"))
+("clss" :version "2019-11-30" :source "quicklisp" :systems ("clss"))
+("collectors" :version "2022-02-20" :source "quicklisp" :systems ("collectors"))
+("colorize" :version "2018-02-28" :source "quicklisp" :systems ("colorize"))
 ("command-line-arguments" :version "2021-08-07" :source "quicklisp" :systems
  ("command-line-arguments"))
+("concrete-syntax-tree" :version "2021-10-21" :source "quicklisp" :systems
+ ("concrete-syntax-tree" "concrete-syntax-tree-base"
+  "concrete-syntax-tree-destructuring" "concrete-syntax-tree-lambda-list"))
+("definitions" :version "2021-05-31" :source "quicklisp" :systems
+ ("definitions"))
+("dissect" :version "2021-05-31" :source "quicklisp" :systems ("dissect"))
 ("documentation-utils" :version "2019-07-11" :source "quicklisp" :systems
  ("documentation-utils"))
+("eclector" :version "2021-10-21" :source "quicklisp" :systems
+ ("eclector" "eclector-concrete-syntax-tree"))
+("esrap" :version "2022-04-01" :source "quicklisp" :systems ("esrap"))
 ("fiveam" :version (:commit "e11dee752a8f59065033ef9d60641d4a2f1e8379") :source
  :implicit-vcs :systems ("fiveam" "fiveam/test"))
+("flexi-streams" :version "2022-02-20" :source "quicklisp" :systems
+ ("flexi-streams"))
+("form-fiddle" :version "2019-07-11" :source "quicklisp" :systems
+ ("form-fiddle"))
 ("global-vars" :version "2014-11-06" :source "quicklisp" :systems
  ("global-vars"))
+("html-encode" :version "2010-10-07" :source "quicklisp" :systems
+ ("html-encode"))
+("hunchentoot" :version "2020-06-10" :source "quicklisp" :systems
+ ("hunchentoot"))
 ("introspect-environment" :version "2022-02-20" :source "quicklisp" :systems
  ("introspect-environment"))
 ("iterate" :version "2021-05-31" :source "quicklisp" :systems ("iterate"))
+("language-codes" :version "2021-05-31" :source "quicklisp" :systems
+ ("language-codes"))
 ("lisp-namespace" :version "2021-10-21" :source "quicklisp" :systems
  ("lisp-namespace"))
 ("lisp-unit" :version "2017-01-24" :source "quicklisp" :systems ("lisp-unit"))
 ("local-time" :version "2021-01-24" :source "quicklisp" :systems ("local-time"))
+("lquery" :version "2020-12-20" :source "quicklisp" :systems ("lquery"))
+("md5" :version "2021-06-30" :source "quicklisp" :systems ("md5"))
+("optima" :version "2015-07-10" :source "quicklisp" :systems ("optima"))
 ("parse-declarations" :version "2010-10-07" :source "quicklisp" :systems
  ("parse-declarations-1.0"))
 ("parse-number" :version "2018-02-28" :source "quicklisp" :systems
  ("parse-number"))
+("pathname-utils" :version "2021-05-31" :source "quicklisp" :systems
+ ("pathname-utils"))
+("plump" :version "2021-06-30" :source "quicklisp" :systems
+ ("plump" "plump-dom"))
+("rfc2388" :version "2018-08-31" :source "quicklisp" :systems ("rfc2388"))
 ("serapeum" :version (:commit "d2985f5e42df11f0e3063625b8432f0a9eca912f")
  :source :implicit-vcs :systems ("serapeum" "serapeum/docs" "serapeum/tests"))
 ("slime" :version "2022-02-20" :source "quicklisp" :systems ("swank"))
 ("sly" :version "2022-04-01" :source "quicklisp" :systems ("slynk"))
 ("split-sequence" :version "2021-05-31" :source "quicklisp" :systems
  ("split-sequence"))
+("staple" :version "2021-10-21" :source "quicklisp" :systems
+ ("staple" "staple-code-parser" "staple-markdown" "staple-markless"
+  "staple-package-recording" "staple-restructured-text" "staple-server"))
 ("string-case" :version "2018-07-11" :source "quicklisp" :systems
  ("string-case"))
 ("sycamore" :version "2021-10-21" :source "quicklisp" :systems ("sycamore"))
+("symbol-munger" :version "2022-02-20" :source "quicklisp" :systems
+ ("symbol-munger"))
 ("trivia" :version "2022-04-01" :source "quicklisp" :systems
  ("trivia" "trivia.balland2006" "trivia.level0" "trivia.level1" "trivia.level2"
   "trivia.trivial"))
@@ -79,15 +138,22 @@
  ("trivial-backtrace"))
 ("trivial-cltl2" :version "2021-12-30" :source "quicklisp" :systems
  ("trivial-cltl2"))
+("trivial-features" :version "2021-12-09" :source "quicklisp" :systems
+ ("trivial-features"))
 ("trivial-file-size" :version "2020-04-27" :source "quicklisp" :systems
  ("trivial-file-size"))
 ("trivial-garbage" :version "2021-12-30" :source "quicklisp" :systems
  ("trivial-garbage"))
+("trivial-gray-streams" :version "2021-01-24" :source "quicklisp" :systems
+ ("trivial-gray-streams"))
 ("trivial-indent" :version "2021-05-31" :source "quicklisp" :systems
  ("trivial-indent"))
 ("trivial-macroexpand-all" :version "2017-10-23" :source "quicklisp" :systems
  ("trivial-macroexpand-all"))
+("trivial-with-current-source-form" :version "2021-10-21" :source "quicklisp"
+ :systems ("trivial-with-current-source-form"))
 ("type-i" :version "2019-12-27" :source "quicklisp" :systems ("type-i"))
+("usocket" :version "2022-04-01" :source "quicklisp" :systems ("usocket"))
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -95,56 +161,186 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 :reverse-dependencies
+("3bmd" ((:system :name "staple-markdown") (:system :name "3bmd"))
+ ((:system :name "staple-markdown") (:system :name "3bmd-ext-code-blocks"))
+ ((:system :name "3bmd-ext-code-blocks") (:system :name "3bmd")))
+
+("acclimation" ((:system :name "eclector") (:system :name "acclimation"))
+ ((:system :name "concrete-syntax-tree-base") (:system :name "acclimation")))
+
 ("alexandria" ((:system :name "type-i") (:system :name "alexandria"))
+ ((:system :name "trivial-with-current-source-form")
+  (:system :name "alexandria"))
  ((:system :name "trivia.level0") (:system :name "alexandria"))
  ((:system :name "trivia.balland2006") (:system :name "alexandria"))
+ ((:system :name "symbol-munger") (:system :name "alexandria"))
  ((:system :name "sycamore") (:system :name "alexandria"))
+ ((:system :name "staple-code-parser") (:system :name "alexandria"))
  ((:system :name "serapeum") (:system :name "alexandria"))
+ ((:system :name "optima") (:system :name "alexandria"))
  ((:system :name "lisp-namespace") (:system :name "alexandria"))
+ ((:system :name "hunchentoot") (:system :name "alexandria"))
  ((:system :name "fiveam") (:system :name "alexandria"))
+ ((:system :name "esrap") (:system :name "alexandria"))
+ ((:system :name "eclector-concrete-syntax-tree") (:system :name "alexandria"))
+ ((:system :name "eclector") (:system :name "alexandria"))
+ ((:system :name "colorize") (:system :name "alexandria"))
+ ((:system :name "collectors") (:system :name "alexandria"))
  ((:system :name "cl-fuzz") (:system :name "alexandria"))
+ ((:system :name "cl-fad") (:system :name "alexandria"))
+ ((:system :name "cl-environments") (:system :name "alexandria"))
+ ((:system :name "cl+ssl") (:system :name "alexandria"))
+ ((:system :name "cffi") (:system :name "alexandria"))
  ((:system :name "bordeaux-threads") (:system :name "alexandria"))
- ((:system :name "alu") (:system :name "alexandria")))
+ ((:system :name "babel") (:system :name "alexandria"))
+ ((:system :name "alu") (:system :name "alexandria"))
+ ((:system :name "3bmd-ext-code-blocks") (:system :name "alexandria"))
+ ((:system :name "3bmd") (:system :name "alexandria")))
 
 ("alu.asd" ((:system :name "alu/test") (:system :name "alu"))
  (t (:asd-file :name "alu.asd")))
 
+("anaphora" ((:system :name "cl-environments") (:system :name "anaphora")))
+
+("array-utils" ((:system :name "plump") (:system :name "array-utils"))
+ ((:system :name "lquery") (:system :name "array-utils"))
+ ((:system :name "clss") (:system :name "array-utils"))
+ ((:system :name "clip") (:system :name "array-utils")))
+
 ("asdf-flv"
  ((:system :name "fiveam") (:system :name "net.didierverna.asdf-flv")))
 
+("asdf-package-system"
+ ((:system :name "alu/documentation") (:system :name "asdf-package-system")))
+
 ("atomics" ((:system :name "serapeum/tests") (:system :name "atomics")))
 
+("babel" ((:system :name "staple") (:system :name "babel"))
+ ((:system :name "cffi") (:system :name "babel")))
+
 ("bordeaux-threads"
- ((:system :name "serapeum") (:system :name "bordeaux-threads")))
+ ((:system :name "serapeum") (:system :name "bordeaux-threads"))
+ ((:system :name "hunchentoot") (:system :name "bordeaux-threads"))
+ ((:system :name "cl-fad") (:system :name "bordeaux-threads"))
+ ((:system :name "cl+ssl") (:system :name "bordeaux-threads")))
+
+("cffi" ((:system :name "cl+ssl") (:system :name "cffi")))
+
+("chunga" ((:system :name "hunchentoot") (:system :name "chunga")))
+
+("cl+ssl" ((:system :name "hunchentoot") (:system :name "cl+ssl")))
+
+("cl-base64" ((:system :name "hunchentoot") (:system :name "cl-base64")))
+
+("cl-data-format-validation"
+ ((:system :name "docutils") (:system :name "data-format-validation")))
+
+("cl-docutils"
+ ((:system :name "staple-restructured-text") (:system :name "docutils")))
+
+("cl-environments" ((:system :name "alu") (:system :name "cl-environments")))
+
+("cl-fad" ((:system :name "hunchentoot") (:system :name "cl-fad")))
 
 ("cl-fuzz" ((:system :name "sycamore") (:system :name "cl-fuzz")))
 
+("cl-markless"
+ ((:system :name "staple-markless") (:system :name "cl-markless-plump"))
+ ((:system :name "cl-markless-plump") (:system :name "cl-markless")))
+
 ("cl-ppcre" ((:system :name "sycamore") (:system :name "cl-ppcre"))
- ((:system :name "serapeum/docs") (:system :name "cl-ppcre")))
+ ((:system :name "staple") (:system :name "cl-ppcre"))
+ ((:system :name "serapeum/docs") (:system :name "cl-ppcre"))
+ ((:system :name "hunchentoot") (:system :name "cl-ppcre"))
+ ((:system :name "docutils") (:system :name "cl-ppcre"))
+ ((:system :name "data-format-validation") (:system :name "cl-ppcre")))
+
+("clip" ((:system :name "staple") (:system :name "clip")))
 
 ("closer-mop" ((:system :name "trivia.level2") (:system :name "closer-mop"))
+ ((:system :name "optima") (:system :name "closer-mop"))
+ ((:system :name "eclector") (:system :name "closer-mop"))
+ ((:system :name "collectors") (:system :name "closer-mop"))
  ((:system :name "alu") (:system :name "closer-mop")))
+
+("clss" ((:system :name "lquery") (:system :name "clss")))
+
+("collectors" ((:system :name "cl-environments") (:system :name "collectors")))
+
+("colorize" ((:system :name "3bmd-ext-code-blocks") (:system :name "colorize")))
 
 ("command-line-arguments"
  ((:system :name "alu") (:system :name "command-line-arguments")))
 
+("concrete-syntax-tree"
+ ((:system :name "staple-code-parser") (:system :name "concrete-syntax-tree"))
+ ((:system :name "staple-code-parser")
+  (:system :name "concrete-syntax-tree-lambda-list"))
+ ((:system :name "staple-code-parser")
+  (:system :name "concrete-syntax-tree-destructuring"))
+ ((:system :name "eclector-concrete-syntax-tree")
+  (:system :name "concrete-syntax-tree"))
+ ((:system :name "concrete-syntax-tree-lambda-list")
+  (:system :name "concrete-syntax-tree-base"))
+ ((:system :name "concrete-syntax-tree-destructuring")
+  (:system :name "concrete-syntax-tree-lambda-list"))
+ ((:system :name "concrete-syntax-tree")
+  (:system :name "concrete-syntax-tree-base"))
+ ((:system :name "concrete-syntax-tree")
+  (:system :name "concrete-syntax-tree-lambda-list")))
+
+("definitions"
+ ((:system :name "staple-code-parser") (:system :name "definitions"))
+ ((:system :name "staple") (:system :name "definitions")))
+
+("dissect" ((:system :name "staple-server") (:system :name "dissect")))
+
 ("documentation-utils"
+ ((:system :name "staple-server") (:system :name "documentation-utils"))
+ ((:system :name "staple-code-parser") (:system :name "documentation-utils"))
+ ((:system :name "staple") (:system :name "documentation-utils"))
+ ((:system :name "plump") (:system :name "documentation-utils"))
+ ((:system :name "language-codes") (:system :name "documentation-utils"))
+ ((:system :name "form-fiddle") (:system :name "documentation-utils"))
+ ((:system :name "definitions") (:system :name "documentation-utils"))
+ ((:system :name "cl-markless") (:system :name "documentation-utils"))
  ((:system :name "atomics") (:system :name "documentation-utils")))
+
+("eclector" ((:system :name "staple-code-parser") (:system :name "eclector"))
+ ((:system :name "staple-code-parser")
+  (:system :name "eclector-concrete-syntax-tree"))
+ ((:system :name "eclector-concrete-syntax-tree") (:system :name "eclector")))
+
+("esrap" ((:system :name "3bmd") (:system :name "esrap")))
 
 ("fiveam" ((:system :name "serapeum/tests") (:system :name "fiveam"))
  ((:system :name "fiveam/test") (:system :name "fiveam"))
  ((:system :name "alu/test") (:system :name "fiveam"))
+ ((:system :name "alu/documentation") (:system :name "fiveam"))
  (t
   (:project :name "fiveam" :commit "e11dee752a8f59065033ef9d60641d4a2f1e8379"
    :source :implicit-vcs)))
 
+("flexi-streams"
+ ((:system :name "hunchentoot") (:system :name "flexi-streams"))
+ ((:system :name "cl+ssl") (:system :name "flexi-streams")))
+
+("form-fiddle" ((:system :name "lquery") (:system :name "form-fiddle")))
+
 ("global-vars" ((:system :name "serapeum") (:system :name "global-vars")))
+
+("html-encode" ((:system :name "colorize") (:system :name "html-encode")))
+
+("hunchentoot" ((:system :name "staple-server") (:system :name "hunchentoot")))
 
 ("introspect-environment"
  ((:system :name "type-i") (:system :name "introspect-environment"))
  ((:system :name "serapeum") (:system :name "introspect-environment")))
 
-("iterate" ((:system :name "trivia.balland2006") (:system :name "iterate")))
+("iterate" ((:system :name "trivia.balland2006") (:system :name "iterate"))
+ ((:system :name "symbol-munger") (:system :name "iterate")))
+
+("language-codes" ((:system :name "staple") (:system :name "language-codes")))
 
 ("lisp-namespace" ((:system :name "type-i") (:system :name "lisp-namespace"))
  ((:system :name "trivia.level2") (:system :name "lisp-namespace")))
@@ -153,10 +349,26 @@
 
 ("local-time" ((:system :name "serapeum/tests") (:system :name "local-time")))
 
+("lquery" ((:system :name "clip") (:system :name "lquery")))
+
+("md5" ((:system :name "hunchentoot") (:system :name "md5")))
+
+("optima" ((:system :name "cl-environments") (:system :name "optima")))
+
 ("parse-declarations"
- ((:system :name "serapeum") (:system :name "parse-declarations-1.0")))
+ ((:system :name "serapeum") (:system :name "parse-declarations-1.0"))
+ ((:system :name "cl-environments") (:system :name "parse-declarations-1.0")))
 
 ("parse-number" ((:system :name "serapeum") (:system :name "parse-number")))
+
+("pathname-utils" ((:system :name "staple") (:system :name "pathname-utils")))
+
+("plump" ((:system :name "plump-dom") (:system :name "plump"))
+ ((:system :name "lquery") (:system :name "plump"))
+ ((:system :name "clss") (:system :name "plump"))
+ ((:system :name "cl-markless-plump") (:system :name "plump-dom")))
+
+("rfc2388" ((:system :name "hunchentoot") (:system :name "rfc2388")))
 
 ("serapeum" ((:system :name "serapeum/tests") (:system :name "serapeum"))
  ((:system :name "serapeum/docs") (:system :name "serapeum"))
@@ -166,15 +378,35 @@
    :source :implicit-vcs)))
 
 ("slime" ((:system :name "serapeum/docs") (:system :name "swank"))
+ ((:system :name "alu/documentation") (:system :name "swank"))
  ((:system :name "alu") (:system :name "swank")))
 
-("sly" ((:system :name "alu") (:system :name "slynk")))
+("sly" ((:system :name "alu/documentation") (:system :name "slynk"))
+ ((:system :name "alu") (:system :name "slynk")))
 
-("split-sequence" ((:system :name "serapeum") (:system :name "split-sequence")))
+("split-sequence" ((:system :name "usocket") (:system :name "split-sequence"))
+ ((:system :name "serapeum") (:system :name "split-sequence"))
+ ((:system :name "colorize") (:system :name "split-sequence"))
+ ((:system :name "3bmd-ext-code-blocks") (:system :name "split-sequence"))
+ ((:system :name "3bmd") (:system :name "split-sequence")))
+
+("staple" ((:system :name "staple-server") (:system :name "staple-markdown"))
+ ((:system :name "staple-server") (:system :name "staple-markless"))
+ ((:system :name "staple-restructured-text") (:system :name "staple"))
+ ((:system :name "staple-markless") (:system :name "staple"))
+ ((:system :name "staple-markdown") (:system :name "staple"))
+ ((:system :name "staple") (:system :name "staple-code-parser"))
+ ((:system :name "staple") (:system :name "staple-package-recording"))
+ ((:system :name "alu/documentation") (:system :name "staple"))
+ ((:system :name "alu/documentation") (:system :name "staple-server"))
+ ((:system :name "alu/documentation")
+  (:system :name "staple-restructured-text")))
 
 ("string-case" ((:system :name "serapeum") (:system :name "string-case")))
 
 ("sycamore" ((:system :name "alu") (:system :name "sycamore")))
+
+("symbol-munger" ((:system :name "collectors") (:system :name "symbol-munger")))
 
 ("trivia" ((:system :name "type-i") (:system :name "trivia.trivial"))
  ((:system :name "trivia.trivial") (:system :name "trivia.level2"))
@@ -186,24 +418,44 @@
  ((:system :name "alu") (:system :name "trivia")))
 
 ("trivial-backtrace"
+ ((:system :name "hunchentoot") (:system :name "trivial-backtrace"))
  ((:system :name "fiveam") (:system :name "trivial-backtrace")))
 
 ("trivial-cltl2"
  ((:system :name "trivia.level2") (:system :name "trivial-cltl2"))
  ((:system :name "serapeum") (:system :name "trivial-cltl2")))
 
+("trivial-features"
+ ((:system :name "cl+ssl") (:system :name "trivial-features"))
+ ((:system :name "cffi") (:system :name "trivial-features"))
+ ((:system :name "babel") (:system :name "trivial-features")))
+
 ("trivial-file-size"
  ((:system :name "serapeum") (:system :name "trivial-file-size")))
 
 ("trivial-garbage"
- ((:system :name "serapeum") (:system :name "trivial-garbage")))
+ ((:system :name "serapeum") (:system :name "trivial-garbage"))
+ ((:system :name "cl+ssl") (:system :name "trivial-garbage")))
+
+("trivial-gray-streams"
+ ((:system :name "flexi-streams") (:system :name "trivial-gray-streams"))
+ ((:system :name "docutils") (:system :name "trivial-gray-streams"))
+ ((:system :name "cl+ssl") (:system :name "trivial-gray-streams"))
+ ((:system :name "chunga") (:system :name "trivial-gray-streams")))
 
 ("trivial-indent"
- ((:system :name "documentation-utils") (:system :name "trivial-indent")))
+ ((:system :name "documentation-utils") (:system :name "trivial-indent"))
+ ((:system :name "cl-markless") (:system :name "trivial-indent")))
 
 ("trivial-macroexpand-all"
  ((:system :name "serapeum/tests") (:system :name "trivial-macroexpand-all"))
  ((:system :name "serapeum") (:system :name "trivial-macroexpand-all")))
 
+("trivial-with-current-source-form"
+ ((:system :name "esrap") (:system :name "trivial-with-current-source-form")))
+
 ("type-i" ((:system :name "trivia.balland2006") (:system :name "type-i")))
+
+("usocket" ((:system :name "hunchentoot") (:system :name "usocket"))
+ ((:system :name "cl+ssl") (:system :name "usocket")))
 

--- a/src/stepper/define.lisp
+++ b/src/stepper/define.lisp
@@ -1,0 +1,4 @@
+(in-package #:alu.stepper.define)
+
+(defmacro defun (name lambda-list &rest body &environment env)
+  `(cl:defun ,name ,lambda-list ,@(step:body body env)))

--- a/src/stepper/package.lisp
+++ b/src/stepper/package.lisp
@@ -8,7 +8,7 @@
 
 (defpackage #:alu.stepper.define
   (:documentation "Provides custom definers that shadow CL base definers")
-  (:shadow :defun)
+  (:shadow #:defun)
   (:use #:common-lisp #:serapeum)
   (:local-nicknames (#:step #:alu.stepper))
   (:export #:defun))

--- a/src/stepper/package.lisp
+++ b/src/stepper/package.lisp
@@ -1,0 +1,7 @@
+(defpackage #:alu.stepper
+  (:documentation "Provides a code walker for CL that can instrument
+  Stack trace information.")
+  (:shadow :step)
+  (:use #:common-lisp #:serapeum)
+  (:local-nicknames (:stack :alu.stack))
+  (:export))

--- a/src/stepper/package.lisp
+++ b/src/stepper/package.lisp
@@ -1,7 +1,14 @@
 (defpackage #:alu.stepper
   (:documentation "Provides a code walker for CL that can instrument
   Stack trace information.")
-  (:shadow :step)
+  (:shadow #:step #:single)
   (:use #:common-lisp #:serapeum)
-  (:local-nicknames (:stack :alu.stack))
-  (:export))
+  (:local-nicknames (#:stack #:alu.stack))
+  (:export #:single #:body #:mode #:*mode*))
+
+(defpackage #:alu.stepper.define
+  (:documentation "Provides custom definers that shadow CL base definers")
+  (:shadow :defun)
+  (:use #:common-lisp #:serapeum)
+  (:local-nicknames (#:step #:alu.stepper))
+  (:export #:defun))

--- a/src/stepper/stepper.lisp
+++ b/src/stepper/stepper.lisp
@@ -314,7 +314,8 @@
                   :macro (mapcar (lambda (x)
                                    (destructuring-bind (name args &rest def) x
                                      (list name
-                                           (cl-environments.cltl2:enclose-macro name args def env))))
+                                           (cl-environments.cltl2:enclose-macro
+                                            name args def env))))
                                  bindings))))
            (body-env
              (if (or macro recursive) new-env env)))

--- a/src/stepper/stepper.lisp
+++ b/src/stepper/stepper.lisp
@@ -47,26 +47,64 @@
 :run   leaves the user program unperturbed.")
 
 
-(defun step (holder)
+(defun step (form env)
   "Runs the stepper through the code, inserting stack traces if
 *step-mode* is :stack"
-  holder)
+  (cond
+    ((eql *step-mode* :run)
+     form)
+    ;; maybe we should macroexpand symbol macros?
+    ;; I don't think for our purposes it matters
+    ((or (atom form) (symbolp form))
+     form)
+    ((special-operator-p (car form))
+     (handle-cl-special form env))
+    ((macro-function (car form) env)
+     ;; we thus record any function and any macro expansion that has
+     ;; been ran as well. This may be helpful, as we are likely going
+     ;; to interpret the stack results. Thus if an error is caused in
+     ;; an expansion but not the users code. it can give information
+     ;; which macro expansion screwed up (namely by comparing the
+     ;; final call to the form where it's first generated... by
+     ;; checking if the car is a macro, and it's the first site it
+     ;; doesn't show up.).
+     (run-mode form
+               (step (macroexpand-1 form env) env)))
+    (t
+     (step-function form env))))
 
-(defun handle-cl-special (form)
+(defun step-function (form env)
+  "Runs the stepper through a function call."
+  (run-mode form
+            (mapcar (lambda (x) (step x env)) form)))
+
+(defmacro with-stack (original-form continue-form)
+  `(prog2 (stack:push ',original-form)
+       ,continue-form
+     (stack:pop)))
+
+(defun run-mode (original-form continue-form)
+  "runs the selected user mode."
+  (etypecase-of step-mode *step-mode*
+    ((eql :run)   original-form)
+    ((eql :stack) `(with-stack ,original-form ,continue-form))))
+
+(defun handle-cl-special (form env)
   (typecase-of specials (car form)
-    ((eql let)       (handle-let form))
-    ((eql let*)      (handle-let form))
-    ((eql eval-when) (handle-eval-when form))
-    ((eql flet))
-    ((eql labels))
+    ((eql let)       (handle-let form env))
+    ((eql let*)      (handle-let form env))
+    ((eql eval-when) (handle-eval-when form env))
+    ((eql flet)      (handle-local-function :recursive nil))
+    ((eql labels)    (handle-local-function :recursive t))
+    ((eql macrolet)  (handle-local-function :recursive t :macro t))
     ((eql block))
     ((eql catch))
+    ((eql symbol-macrolet))
     ((eql function))
     ((eql go))
     ((eql if))
     ((eql load-time-value))
     ((eql locally))
-    ((eql macrolet))
     ((eql multiple-vlaue-call))
     ((eql multiple-value-prog1))
     ((eql progn))
@@ -74,7 +112,6 @@
     ((eql quote))
     ((eql return-from))
     ((eql setq))
-    ((eql symbol-macrolet))
     ((eql tagbody))
     ((eql the))
     ((eql throw))
@@ -82,10 +119,10 @@
     (otherwise
      (error "special ~A not supported yet" (car form)))))
 
-(defun handle-alu-special (form)
+(defun handle-alu-special (form env)
   (typecase-of alu-specials (car form)
-    ((eql alu:def)             (handle-let form t))
-    ((eql alu:with-constraint) (handle-constraint form))
+    ((eql alu:def)             (handle-let form env t))
+    ((eql alu:with-constraint) (handle-constraint form env))
     ((eql alu:coerce))
     ((eql alu:check))
     ((eql alu:array))
@@ -94,33 +131,55 @@
 
 ;; TODO :: Major Flaw
 ;;
+;; Note Early:
 ;; for binders like let and flet we need to freeze with a lambda
 ;; technique.  generate out to a lambda call, further we should pass
-;; around the environment so that we refer to the correct values
-(defun handle-let (form &optional handle-constrain)
+;; around the environment so that we refer to the correct values. Or
+;; rather we should continue in that lambda, thus generate out a
+;; lambda to continue this evaluation. Rather cheeky all things considered
+;;
+;; Note Later:
+;; seems like we can just use the env variable, and update it with
+;; `cltl2:augment-environment' to get it to work
+
+(defun handle-let (form env &optional handle-constrain)
+  ;; we don't need to update the environment as we don't care about
+  ;; symbols as much.
   (destructuring-bind (let args &rest body) form
-    (list* let (handle-binder args handle-constrain) (handle-body body))))
+    (list* let (handle-binder args handle-constrain) (handle-body body env))))
 
-(defun handle-eval-when (form)
+(defun handle-eval-when (form env)
   (destructuring-bind (eval-when declaration &rest body) form
-    (list* eval-when declaration (handle-body body))))
+    (list* eval-when declaration (handle-body body env))))
 
-(defun handle-binder (binders &optional handle-constrain)
+(defun handle-binder (binders env &optional handle-constrain)
   (mapcar (lambda (bind-pair)
             (if (and handle-constrain (eql (car bind-pair) 'alu:with-constraint))
-                (handle-constraint bind-pair)
-                ;; TODO ∷ STEP is wrong here due to introducing a binder which is not a macro
-                (step bind-pair)))
+                (handle-constraint bind-pair env)
+                ;; TODO ∷ STEP is wrong here due to introducing a
+                ;; binder which is not a macro
+                (step bind-pair env)))
           binders))
 
-(defun handle-body (body)
+(defun handle-local-function (form env &key recursive macro)
+  "Handles functions like flet, labels, and macrolet.
+
+:recursive   means that the binding is recursive and should be all
+             considered together
+:macro       means the binding form should be considered a macro. We
+             assume the macro is also :recursive t
+"
+  (list form env macro recursive))
+
+(defun handle-body (body env)
   "Handles a body that may have declarations upfront"
   (mapcar (lambda (x)
-            (if (declarationp x) x (step x)))
+            (if (and (listp x) (declarationp x)) x (step x env)))
           body))
 
-(defun handle-constraint (form)
+(defun handle-constraint (form env)
   "Handles an `alu:with-constraint' form"
+  env
   form)
 
 (defun declarationp (form)

--- a/src/stepper/stepper.lisp
+++ b/src/stepper/stepper.lisp
@@ -1,0 +1,20 @@
+(in-package :alu.stepper)
+
+;; The strategy we wish to implement is straight forward.
+
+;; (step (macro ...)) ⟶ we macroexpand the macro
+;;
+;; (step (special-form ...)) ⟶ We handle this on a case by case basis
+;;
+;; (step (alucard-special-macro ...)) ⟶ Handle the same as special-form
+;;
+;; (step (function ...)) ⟶ generates out
+;;   (prog2 (push (function …)) (function ,@(mapcar #'step …)) (pop))
+;; (step number) ⟶ generates: number
+;; (step string) ⟶ generates: string
+;; (step symbol) ⟶ generates: symbol
+
+
+
+(defun step (holder)
+  holder)

--- a/src/stepper/stepper.lisp
+++ b/src/stepper/stepper.lisp
@@ -9,12 +9,83 @@
 ;; (step (alucard-special-macro ...)) ⟶ Handle the same as special-form
 ;;
 ;; (step (function ...)) ⟶ generates out
-;;   (prog2 (push (function …)) (function ,@(mapcar #'step …)) (pop))
+;;   (prog2 (push (function …)) (function ,@(map car #'step …)) (pop))
 ;; (step number) ⟶ generates: number
 ;; (step string) ⟶ generates: string
 ;; (step symbol) ⟶ generates: symbol
 
+;; For the list of special forms see
+;; https://www.cs.cmu.edu/Groups/AI/html/cltl/clm/node59.html
+
+;; to actually check one should use `special-operator-p' instead of
+;; (typep obj 'specials).
+(deftype specials ()
+  "The special forms of the CL language"
+  `(or ,@(mapcar
+          (lambda (x) `(eql ,x))
+          `(block catch eval-when flet function go if
+                  labels let let* load-time-value locally
+                  macrolet multiple-vlaue-call
+                  multiple-value-prog1 progn progv
+                  quote return-from setq symbol-macrolet
+                  tagbody the throw unwind-protect))))
+
+(deftype alu-specials ()
+  "The special forms of the Alucard language"
+  `(or (eql alu:def) (eql alu:with-constraint)
+       ;; these we count as special due to the type declaration
+       ;; forcing them to be macros
+       (eql alu:coerce) (eql alu:check)
+       (eql alu:array)))
+
+(deftype step-mode ()
+  `(or (eql :stack) (eql :run)))
+
+(defvar *step-mode* :stack
+  "Determines what mode to run in.
+:stack put user syntactical forms on the stack.
+:run   leaves the user program unperturbed.")
 
 
 (defun step (holder)
   holder)
+
+(defun handle-cl-special (form)
+  (typecase-of specials (car form)
+    ((eql block))
+    ((eql catch))
+    ((eql eval-when))
+    ((eql flet))
+    ((eql function))
+    ((eql go))
+    ((eql if))
+    ((eql labels))
+    ((eql let))
+    ((eql let*))
+    ((eql load-time-value))
+    ((eql locally))
+    ((eql macrolet))
+    ((eql multiple-vlaue-call))
+    ((eql multiple-value-prog1))
+    ((eql progn))
+    ((eql progv))
+    ((eql quote))
+    ((eql return-from))
+    ((eql setq))
+    ((eql symbol-macrolet))
+    ((eql tagbody))
+    ((eql the))
+    ((eql throw))
+    ((eql unwind-protect))
+    (otherwise
+     (error "special ~A not supported yet" (car form)))))
+
+(defun handle-alu-special (form)
+  (typecase-of alu-specials (car form)
+    ((eql alu:def))
+    ((eql alu:with-constraint))
+    ((eql alu:coerce))
+    ((eql alu:check))
+    ((eql alu:array))
+    (otherwise (error "Alucard Special ~A handed to handle-alu special"
+                      form))))

--- a/src/stepper/stepper.lisp
+++ b/src/stepper/stepper.lisp
@@ -183,7 +183,7 @@
   ;; we don't need to update the environment as we don't care about
   ;; symbols as much.
   (destructuring-bind (let args &rest body) form
-    (list* let (handle-binder args handle-constrain) (step-body body env))))
+    (list* let (handle-binder args env handle-constrain) (step-body body env))))
 
 (defun handle-eval-when (form env)
   (destructuring-bind (eval-when declaration &rest body) form
@@ -313,7 +313,8 @@
                   env
                   :macro (mapcar (lambda (x)
                                    (destructuring-bind (name args &rest def) x
-                                     (cltl2:parse-macro name args def env)))
+                                     (list name
+                                           (cl-environments.cltl2:enclose-macro name args def env))))
                                  bindings))))
            (body-env
              (if (or macro recursive) new-env env)))

--- a/test/package.lisp
+++ b/test/package.lisp
@@ -19,7 +19,9 @@
                     (:vspc     :alu.vampir.spec)
                     (:prld     :alu.prelude)
                     (:ref      :alu.reference)
-                    (:stack    :alu.stack))
+                    (:stack    :alu.stack)
+                    (:step     :alu.stepper)
+                    (:step.def :alu.stepper.define))
   (:export #:run-tests))
 
 (in-package :alu-test)

--- a/test/run-tests.lisp
+++ b/test/run-tests.lisp
@@ -12,6 +12,7 @@
    'alucard.evaluate-body
    'alucard.packing
    'alucard.stack
+   'alucard.step
    'vampir
    'alucard))
 

--- a/test/stack.lisp
+++ b/test/stack.lisp
@@ -5,7 +5,6 @@
 
 (in-suite alucard.stack)
 
-
 (test dynamic-variable-respected
   (let ((current-stack (stack:get)))
     (stack:with-empty-stack ()

--- a/test/step.lisp
+++ b/test/step.lisp
@@ -22,6 +22,51 @@
 (step.def:defun expansion-call ()
   (expansion-test (stack:get)))
 
+(step.def:defun local-expansion-test (x)
+  (flet ((expansion-test (x) (list x (stack:get))))
+    (expansion-test x)))
+
+(step.def:defun local-expansion-test-labels (x)
+  (labels ((expansion-test (x) (list x (stack:get)))
+           (faz (x) (expansion-test x)))
+    (faz x)))
+
+(step.def:defun lets-explore (x)
+  (funcall (lambda (x) (+ x 5)) x))
+
+(step.def:defun macro-let-test ()
+  (macrolet ((lets-explore (x) `(progn ,x)))
+    (lets-explore (stack:get))))
+
+;; just checking all these run fine, with no issues
+(step.def:defun alu-primitives (x y)
+  (declare (ignore y))
+
+  (prld:def ((prld:with-constraint (b2 b3)
+               (prld:= x (prld:+ b2 b3))))
+    (prld:with-constraint (b2 b3)
+      (prld:= x (prld:+ b2 b3)))
+
+    (alu:array 512 (int 1))
+
+    (def ((bit-array (aluser::reshape x 512 :type (int 1))))
+      (prld:get bit-array x))
+
+    (prld:= (prld:+ (prld:exp x 3)
+                    (prld:* 3 (prld:exp x 2))
+                    (prld:* 2 x)
+                    4)
+            0)
+
+    (prld:def ((bar (prld:to-array 36)))
+      (prld:+ (prld:check 5 (int 32))
+              (prld:get bar 0)))))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Doing Examples from the wiki
+;; to see if our code walks properly
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 (step.def:defun prince-of-clarity (w)
   "Take a cons of two lists and make a list of conses.
    Think of this function as being like a zipper."
@@ -52,28 +97,28 @@
      (setq z y)
      (go rejoin)))
 
-(step.def:defun local-expansion-test (x)
-  (flet ((expansion-test (x) (list x (stack:get))))
-    (expansion-test x)))
+(step.def:defun throwing-test ()
+  (catch 'foo
+    (format t "The inner catch returns ~s.~%"
+            (catch 'foo
+              (unwind-protect (throw 'foo :first-throw)
+                (throw 'foo :second-throw))))
+    (the keyword :outer-catch)))
 
-(step.def:defun alu-primitives (x)
-  (prld:with-constraint (b2 b3)
-    (prld:= x (prld:+ b2 b3)))
-  (prld:= (prld:+ (prld:exp x 3)
-                  (prld:* 3 (prld:exp x 2))
-                  (prld:* 2 x)
-                  4)
-          0)
-  (prld:def ((bar (prld:to-array 36)))
-    (prld:+ (prld:check 5 (int 32))
-            (prld:get bar 0))))
-
-(step.def:defun lets-explore (x)
-  (funcall (lambda (x) (+ x 5)) x))
-
-(step.def:defun macro-let-test ()
-  (macrolet ((lets-explore (x) `(progn ,x)))
-    (lets-explore (stack:get))))
+(step.def:defun rest-test ()
+  (list
+   (equalp (multiple-value-call #'list 1 '/ (values 2 3) '/ (values) '/ (floor 2.5))
+           '(1 / 2 3 / / 2 0.5))
+   (let* ((temp '(1 2 3)))
+     (equalp 1
+             (multiple-value-prog1
+                 (values-list temp)
+               (setq temp nil)
+               (values-list temp))))
+   (equalp '(3 4)
+           (let ((x 3))
+             (progv '(x) '(4)
+               (list x (symbol-value 'x)))))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Tests
@@ -90,9 +135,22 @@
   (is
    (equalp (local-expansion-test 5)
            '(5
-             ((STACK:GET) (LIST X (STACK:GET)) (EXPANSION-TEST X)
+             ((STACK:GET)
+              (LIST X (STACK:GET))
+              (EXPANSION-TEST X)
               (FLET ((EXPANSION-TEST (X) (LIST X (STACK:GET)))) (EXPANSION-TEST X)))))
    "Fletting beats macros!")
+  (is
+   (equalp (local-expansion-test-labels 3)
+           '(3
+             ((STACK:GET)
+              (LIST X (STACK:GET))
+              (EXPANSION-TEST X)
+              (FAZ X)
+              (LABELS ((EXPANSION-TEST (X) (LIST X (STACK:GET)))
+                       (FAZ (X) (EXPANSION-TEST X)))
+                (FAZ X)))))
+   "Labels removes the recursive macro calls")
   (is (= (length (macro-let-test))
          4)
       "Macro expansion from a macrolet works as expected"))
@@ -110,4 +168,6 @@
       "lambda should not loop forever")
   (is (equalp (stack:get) nil)
       "Cleanup should be had after all these calls!")
-  (finishes (alu-primitives 3)))
+  (finishes (alu-primitives 3 5))
+  (is (eql (throwing-test) :outer-catch))
+  (is (every #'identity (rest-test))))

--- a/test/step.lisp
+++ b/test/step.lisp
@@ -1,0 +1,69 @@
+(in-package :alu-test)
+
+(def-suite alucard.step
+  :description "Testing the stepper")
+
+(in-suite alucard.step)
+
+(step.def:defun base ()
+  (car (list (stack:get))))
+
+(step.def:defun calling-base ()
+  (if (listp (base))
+      (base)))
+
+(defmacro expansion-test (x)
+  `(progn ,x))
+
+(step.def:defun expansion-call ()
+  (expansion-test (stack:get)))
+
+(step.def:defun king-of-confusion (w)
+  "Take a cons of two lists and make a list of conses.
+    Think of this function as being like a zipper."
+  (prog (x y z)                         ;Initialize x, y, z to NIL
+     (setq y (car w) z (cdr w))
+   loop
+     (cond ((null y) (return x))
+           ((null z) (go err)))
+   rejoin
+     (setq x (cons (cons (car y) (car z)) x))
+     (setq y (cdr y) z (cdr z))
+     (go loop)
+   err
+     (cerror "Will self-pair extraneous items"
+             "Mismatch - gleep!  ~S" y)
+     (setq z y)
+     (go rejoin)))
+
+(step.def:defun local-expansion-test (x)
+  (flet ((expansion-test (x) (list x (stack:get))))
+    (expansion-test x)))
+
+(step.def:defun lets-explore (x)
+  (funcall (lambda (x) (+ x 5)) x))
+
+(test nesting-respected
+  (is (>= (length (calling-base)) 3)
+      "calling a traced function should have the parents call put in there as well!"))
+
+(test macro-expected
+  (is (equalp (expansion-call)
+              '((STACK:GET) (PROGN (STACK:GET)) (EXPANSION-TEST (STACK:GET))))
+      "The macro should be recorded wholesale along with it's expansion")
+  (is
+   (equalp (local-expansion-test 5)
+           '(5
+             ((STACK:GET) (LIST X (STACK:GET)) (EXPANSION-TEST X)
+              (FLET ((EXPANSION-TEST (X) (LIST X (STACK:GET)))) (EXPANSION-TEST X)))))
+   "Fletting beats macros!"))
+
+(test instrumentation-does-not-interfere
+  (is (equalp (king-of-confusion (cons (list 1 2 3)
+                                       (list 4 6 7)))
+              '((3 . 7) (2 . 6) (1 . 4)))
+      "Instrumenting simply adds debugging information does not change semantics")
+  (is (equalp (lets-explore 10) 15)
+      "lambda should not loop forever")
+  (is (equalp (stack:get) nil)
+      "Cleanup should be had after all these calls!"))


### PR DESCRIPTION
This adds Instrumenting definitions to fulfill the back-trace portion of #19.

This PR will likely be overkill in the sense, that I'll be storing large portions of the syntax stack down to any particular alucard operation. This means that we will have access to all the expressions that lead to the issue expression. This overkill is needed, as users can write CL functions which will inline their logic inside a `defcircuit`, meaning that'll emit instructions that do not show up in the user code directly! Thus we should be able to tell that the instruction came from the outside function `foo`, and give a stack trace of where the line showed up in the `defcircuit` along with where it showed up in any CL function it may have called.  

I hope this is enough information to guarantee future work of taking the stack trace, and figuring off the offset of the logic from the location where the function is defined, giving back precise locations of where all these errors occur.

 Future work can be made integrating this into the SLY/SWANK debugger, giving a normal debugging interface to the problem in the listener 